### PR TITLE
Add Data menu with overview and subpages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
-import { BrowserRouter as Router, Routes, Route, NavLink } from 'react-router-dom';
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  NavLink,
+  useLocation,
+} from 'react-router-dom';
 import './index.css';
 import NavBar from './NavBar';
 import ImportPage from './pages/ImportPage';
@@ -7,101 +13,83 @@ import MappingPage from './pages/MappingPage';
 import TransformPage from './pages/TransformPage';
 import UploadPage from './pages/UploadPage';
 import OnlineCheckPage from './pages/OnlineCheckPage';
+import DataOverviewPage from './pages/DataOverviewPage';
+import DataSourcesPage from './pages/DataSourcesPage';
+import DataCleanupPage from './pages/DataCleanupPage';
 import { ImporterProvider } from './context/ImporterContext';
 
-function App() {
+function Layout() {
   const [collapsed, setCollapsed] = useState(false);
+  const location = useLocation();
+  const isData = location.pathname.startsWith('/data');
 
+  const menuItems = isData
+    ? [
+        { to: '/data', label: 'Übersicht', end: true },
+        { to: '/data/sources', label: 'Quellen' },
+        { to: '/data/cleanup', label: 'Cleanup' },
+      ]
+    : [
+        { to: '/', label: 'Import', end: true },
+        { to: '/mapping', label: 'Mapping' },
+        { to: '/transform', label: 'Transform' },
+        { to: '/upload', label: 'Upload' },
+        { to: '/online-check', label: 'Online Check' },
+      ];
+
+  return (
+    <div className="flex flex-col h-full">
+      <NavBar onToggle={() => setCollapsed(!collapsed)} />
+      <div className="flex flex-1 overflow-hidden">
+        <aside
+          className={`bg-menu border-r border-gray-400 p-4 transition-all duration-300 overflow-auto ${
+            collapsed ? 'w-0' : 'w-64'
+          }`}
+        >
+          <p className="font-semibold mb-2">{isData ? 'Data' : 'Import'}</p>
+          <ul className="space-y-2">
+            {menuItems.map(({ to, label, end }) => (
+              <li key={to}>
+                <NavLink
+                  to={to}
+                  {...(end ? { end: true } : {})}
+                  className={({ isActive }) =>
+                    `block rounded border border-gray-300 p-2 text-sm ${
+                      isActive ? 'bg-navitem' : 'bg-white'
+                    }`
+                  }
+                >
+                  {label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </aside>
+        <main className="flex-1 overflow-auto p-4">
+          <Routes>
+            <Route path="/" element={<ImportPage />} />
+            <Route path="/mapping" element={<MappingPage />} />
+            <Route path="/transform" element={<TransformPage />} />
+            <Route path="/upload" element={<UploadPage />} />
+            <Route path="/online-check" element={<OnlineCheckPage />} />
+            <Route path="/data" element={<DataOverviewPage />} />
+            <Route path="/data/sources" element={<DataSourcesPage />} />
+            <Route path="/data/cleanup" element={<DataCleanupPage />} />
+          </Routes>
+        </main>
+      </div>
+      <footer className="bg-menu border-t border-gray-400 p-2 text-sm">
+        Statusleiste
+      </footer>
+    </div>
+  );
+}
+
+function App() {
   return (
     <Router>
       <ImporterProvider>
-        <div className="flex flex-col h-full">
-          <NavBar onToggle={() => setCollapsed(!collapsed)} />
-          <div className="flex flex-1 overflow-hidden">
-            <aside
-              className={`bg-menu border-r border-gray-400 p-4 transition-all duration-300 overflow-auto ${
-                collapsed ? 'w-0' : 'w-64'
-              }`}
-            >
-              <p className="font-semibold mb-2">Import</p>
-              <ul className="space-y-2">
-                <li>
-                  <NavLink
-                    to="/"
-                    end
-                    className={({ isActive }) =>
-                      `block rounded border border-gray-300 p-2 text-sm ${
-                        isActive ? 'bg-navitem' : 'bg-white'
-                      }`
-                    }
-                  >
-                    Import
-                  </NavLink>
-                </li>
-                <li>
-                  <NavLink
-                    to="/mapping"
-                    className={({ isActive }) =>
-                      `block rounded border border-gray-300 p-2 text-sm ${
-                        isActive ? 'bg-navitem' : 'bg-white'
-                      }`
-                    }
-                  >
-                    Mapping
-                  </NavLink>
-                </li>
-                <li>
-                  <NavLink
-                    to="/transform"
-                    className={({ isActive }) =>
-                      `block rounded border border-gray-300 p-2 text-sm ${
-                        isActive ? 'bg-navitem' : 'bg-white'
-                      }`
-                    }
-                  >
-                    Transform
-                  </NavLink>
-                </li>
-                <li>
-                  <NavLink
-                    to="/upload"
-                    className={({ isActive }) =>
-                      `block rounded border border-gray-300 p-2 text-sm ${
-                        isActive ? 'bg-navitem' : 'bg-white'
-                      }`
-                    }
-                  >
-                    Upload
-                  </NavLink>
-                </li>
-                <li>
-                  <NavLink
-                    to="/online-check"
-                    className={({ isActive }) =>
-                      `block rounded border border-gray-300 p-2 text-sm ${
-                        isActive ? 'bg-navitem' : 'bg-white'
-                      }`
-                    }
-                  >
-                    Online Check
-                  </NavLink>
-                </li>
-              </ul>
-            </aside>
-            <main className="flex-1 overflow-auto p-4">
-              <Routes>
-                <Route path="/" element={<ImportPage />} />
-                <Route path="/mapping" element={<MappingPage />} />
-                <Route path="/transform" element={<TransformPage />} />
-                <Route path="/upload" element={<UploadPage />} />
-                <Route path="/online-check" element={<OnlineCheckPage />} />
-              </Routes>
-            </main>
-          </div>
-          <footer className="bg-menu border-t border-gray-400 p-2 text-sm">
-            Statusleiste
-          </footer>
-        </div>
+        <Layout />
       </ImporterProvider>
     </Router>
   );

--- a/client/src/NavBar.tsx
+++ b/client/src/NavBar.tsx
@@ -26,7 +26,12 @@ function NavBar({ onToggle }: NavBarProps) {
             Import
           </NavLink>
         </li>
-        
+        <li>
+          <NavLink to="/data" className={linkStyle}>
+            Data
+          </NavLink>
+        </li>
+
       </ul>
     </nav>
   );

--- a/client/src/pages/DataCleanupPage.tsx
+++ b/client/src/pages/DataCleanupPage.tsx
@@ -1,0 +1,10 @@
+function DataCleanupPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Data Cleanup</h1>
+      <p>Daten bearbeiten und bereinigen.</p>
+    </div>
+  );
+}
+
+export default DataCleanupPage;

--- a/client/src/pages/DataOverviewPage.tsx
+++ b/client/src/pages/DataOverviewPage.tsx
@@ -1,0 +1,10 @@
+function DataOverviewPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Data Overview</h1>
+      <p>Übersicht über vorhandene Daten.</p>
+    </div>
+  );
+}
+
+export default DataOverviewPage;

--- a/client/src/pages/DataSourcesPage.tsx
+++ b/client/src/pages/DataSourcesPage.tsx
@@ -1,0 +1,10 @@
+function DataSourcesPage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">Data Sources</h1>
+      <p>Quellen der importierten Daten verwalten.</p>
+    </div>
+  );
+}
+
+export default DataSourcesPage;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,5 +5,5 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [ tailwindcss(),,react()],
+  plugins: [tailwindcss(), react()],
 })


### PR DESCRIPTION
## Summary
- add Data main navigation entry
- show import or data links in sidebar depending on active section
- create simple Data pages
- fix lint error in vite config

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6858558ceb088328b1632e2becda5b28